### PR TITLE
Allow Local Manifests to be used easier

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
+  <remote  name="github"
+           fetch="https://github.com" />
   <remote  name="aosp"
            fetch="https://android.googlesource.com"
            review="android-review.googlesource.com" />


### PR DESCRIPTION
This will allow us to use roomservice to call in non-pure repos should it be needed.